### PR TITLE
Resolve clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,8 +549,7 @@ fn main() {
             }; // endof sentence
 
             // The line has to have VDM in it
-            let isais = line.find("VDM");
-            if line.find("VDM") == None {
+            if !line.contains("VDM") {
                 continue;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ fn readable(mut o_s: String) -> String {
     if negative {
         s.insert(0, '-');
     }
-    return s;
+    s
 } // fn readable
 
 // Parse the AIS payload by extracting the message type, slicing out the bit values
@@ -202,16 +202,16 @@ fn decode_payload(mut line: PositionReport) -> PositionReport {
             // Message values not covered by the above cases.
         }
     }
-    return line;
+    line
 }
 
 // Take the last four characters of a string slice.
 fn last_four_characters(text: &str) -> &str {
     let len = text.len();
     if len > 3 {
-        return &text[len - 4..len];
+        &text[len - 4..len]
     } else {
-        return "";
+        ""
     }
 } // endof last_four_characters
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ fn decode_payload(mut line: PositionReport) -> PositionReport {
             let minute = pick_u64(&payload, 288, 6);
             let datestub = minute * 60 + hour * 3600 + day * 86400 + month * 2678400;
             let year: f64 = {
-                if line.satellite_acquisition_time != "" {
+                if !line.satellite_acquisition_time.is_empty() {
                     line.satellite_acquisition_time.parse::<f64>().unwrap() / 31_536_000.0
                 } else {
                     "0".parse::<f64>().unwrap()
@@ -515,7 +515,7 @@ fn main() {
 
                 // If it's a single-line message, send it to the output channel
                 // Otherwise push it to the multiline handler
-                if line.group == "" {
+                if line.group.is_empty() {
                     line.message_class = "singleline".to_string();
                     let line = decode_payload(line);
                     extract_ready_for_output_tx.send(serde_json::to_string(&line).unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use bitvec::prelude::*;
 use clap::{App, Arg};
 use crossbeam_channel::{bounded, Receiver, Sender};
 use hashbrown::HashMap;
-use num_cpus;
 use regex::Regex;
 use serde::Serialize;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,12 +312,9 @@ fn main() {
 
     // Initiate Hashmaps for multisentence AIS messages
     // These are wrapped by ARC and Mutexes for use under multithreading.
-    let mut payload_cache: Arc<Mutex<HashMap<String, String>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    let mut source_cache: Arc<Mutex<HashMap<String, String>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    let mut sat_time_cache: Arc<Mutex<HashMap<String, String>>> =
-        Arc::new(Mutex::new(HashMap::new()));
+    let payload_cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+    let source_cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+    let sat_time_cache: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
 
     /*
     Create the crossbeam channels to relay the data across threads.
@@ -360,9 +357,9 @@ fn main() {
 
     for _b in 0..n_workers {
         // Initiate Hashmaps for multisentence AIS messages
-        let payload_cache = Arc::clone(&mut payload_cache);
-        let source_cache = Arc::clone(&mut source_cache);
-        let sat_time_cache = Arc::clone(&mut sat_time_cache);
+        let payload_cache = Arc::clone(&payload_cache);
+        let source_cache = Arc::clone(&source_cache);
+        let sat_time_cache = Arc::clone(&sat_time_cache);
 
         // Clonen an output channel for use in the threads
         let ready_for_output_tx = ready_for_output_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,7 +439,8 @@ fn main() {
                         };
                         // println!("Combined multiline: {:?}", line);
                         line = decode_payload(line);
-                        ready_for_output_tx.send(serde_json::to_string(&line).unwrap());
+                        let line_json = serde_json::to_string(&line).unwrap();
+                        ready_for_output_tx.send(line_json).unwrap();
                     }
 
                     // *******
@@ -515,7 +516,8 @@ fn main() {
                 if line.group.is_empty() {
                     line.message_class = "singleline".to_string();
                     let line = decode_payload(line);
-                    extract_ready_for_output_tx.send(serde_json::to_string(&line).unwrap());
+                    let line_json = serde_json::to_string(&line).unwrap();
+                    extract_ready_for_output_tx.send(line_json).unwrap();
 
                     // extract_ready_for_output_tx.send(line).unwrap();
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,7 +474,7 @@ fn main() {
             while let Ok(mut line) = raw_file_rx.recv_timeout(Duration::from_millis(queue_timeout))
             {
                 // Split the comma delimited line and pick out the payload and other elements
-                let payload = &line.sentence.split(",").collect::<Vec<_>>();
+                let payload = &line.sentence.split(',').collect::<Vec<_>>();
                 line.channel = payload[payload.len() - 3].to_string();
                 line.raw_payload = payload[payload.len() - 2].to_string();
                 // println!("RAW: Payload: {:?}", line.raw_payload);
@@ -595,7 +595,7 @@ fn main() {
         if counter % 100000 == 0 {
             println!("Writing {} lines to file.", readable(counter.to_string()));
         }
-        write!(buf, "{}\n", line);
+        writeln!(buf, "{}", line).unwrap();
     }
 
     // wait for the threads to complete

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,12 +403,12 @@ fn main() {
                     payload_lock.insert(line.group.clone(), line.raw_payload.clone());
 
                     // insert into time cache if parsed_line[3] is not empty
-                    if line.satellite_acquisition_time.len() > 0 {
+                    if !line.satellite_acquisition_time.is_empty() {
                         sat_time_lock.insert(line.group.clone(), line.satellite_acquisition_time);
                     }
 
                     // insert into source_cache if parsed_line[3] is not empty
-                    if line.source.len() > 0 {
+                    if !line.source.is_empty() {
                         source_lock.insert(line.group.clone(), line.source);
                     }
 


### PR DESCRIPTION
Hi Scott, thanks for the write up! I enjoyed it.

I took the opportunity to run the code through [clippy](https://github.com/rust-lang/rust-clippy#readme), the Rust language's idiomatic language linter, and fixed some of its warnings. I've attached the fix for each lint as a separate commit with a link to the description of the lint.

I really enjoy working with Clippy to arrive at idiomatic Rust code. Sometimes it takes several run-ins with conflicting lints, as it did with 6745bde5693d14b17e4fb81debb99ba712ae9c50, but it ends up producing really nice code. I highly recommend integrating Clippy with your editor if you can. Here's an example of what VS Code looks like with clippy's warning integrated into the editor:
<img width="1582" alt="Screen Shot 2022-07-07 at 12 00 27 PM" src="https://user-images.githubusercontent.com/2836167/177829653-c249baf1-f4a1-4d5a-b829-cea1cb248103.png">

Anyway, thanks again for writing the blog post!

Best,
Brian