### PR TITLE
Bugfix for `EXTRACTION_THREADS` is not an id of an argument or a group

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,7 @@ fn main() {
 
     // Match the parse_threads variable
     let extraction_threads: usize = {
-        if let Some(i) = matches.value_of("EXTRACTION_THREADS") {
+        if let Some(i) = matches.value_of("PARSE_THREADS") {
             i.parse::<usize>().unwrap()
         } else {
             // default value


### PR DESCRIPTION
Looks like a string label was out of sync.

# Steps to reproduce

1. Check out the repo and the git-lfs file `norway.nmea`
2. Issue command: `$ cargo run -- norway.nmea norway.out`
3. Result: Application panics (see below)

<img width="1385" alt="Screen Shot 2022-07-11 at 11 25 16 AM" src="https://user-images.githubusercontent.com/2836167/178311982-7156809d-13d8-4691-9175-310c94a53b96.png">

Fix included in this PR.
